### PR TITLE
Allow domain part of Azure git URL to be customized for ASE

### DIFF
--- a/lib/azure-deploy-websites-deployment-manager.js
+++ b/lib/azure-deploy-websites-deployment-manager.js
@@ -8,20 +8,21 @@ var azureDeployFs = require('./azure-deploy-fs.js');
 
 module.exports = AzureWebSiteDeploymentManager;
 
-function AzureWebSiteDeploymentManager(azureWebSiteName, azureDeploymentCredentialUserName, azureDeploymnetCredentialPassword, azureDeploymentDomain) {
+function AzureWebSiteDeploymentManager(azureWebSiteName, azureDeploymentCredentialUserName, azureDeploymnetCredentialPassword, azureDeploymentDomain, azureProjectName) {
     var self = this;
 
     self.azureWebSiteName = azureWebSiteName;
     self.azureUserName = azureDeploymentCredentialUserName;
     self.azurePassword = azureDeploymnetCredentialPassword;
-    self.azureDeploymentDomain = (typeof azureDeploymentDomain === 'undefined') ? 'scm.azurewebsites.net' : azureDeploymentDomain;
+    self.azureDeploymentDomain = (azureDeploymentDomain) ? azureDeploymentDomain : 'scm.azurewebsites.net';
+    self.azureProjectName = (azureProjectName) ? azureProjectName : azureWebSiteName;
 }
 
 AzureWebSiteDeploymentManager.prototype.deploy = function (sourceDir) {
     var self = this;
 
     // https://{{username}}:{{password}}@{{project}}.scm.azurewebsites.net:443/{{project}}.git
-    var repositoryUri = "https://" + self.azureUserName + ":" + self.azurePassword + "@" + self.azureWebSiteName + "." + self.azureDeploymentDomain + ":443/" + self.azureWebSiteName + ".git";
+    var repositoryUri = "https://" + self.azureUserName + ":" + self.azurePassword + "@" + self.azureWebSiteName + "." + self.azureDeploymentDomain + ":443/" + self.azureProjectName + ".git";
 
     var currentTempDir;
     var currentGitRepository;

--- a/lib/azure-deploy-websites-deployment-manager.js
+++ b/lib/azure-deploy-websites-deployment-manager.js
@@ -8,19 +8,20 @@ var azureDeployFs = require('./azure-deploy-fs.js');
 
 module.exports = AzureWebSiteDeploymentManager;
 
-function AzureWebSiteDeploymentManager(azureWebSiteName, azureDeploymentCredentialUserName, azureDeploymnetCredentialPassword) {
+function AzureWebSiteDeploymentManager(azureWebSiteName, azureDeploymentCredentialUserName, azureDeploymnetCredentialPassword, azureDeploymentDomain) {
     var self = this;
 
     self.azureWebSiteName = azureWebSiteName;
     self.azureUserName = azureDeploymentCredentialUserName;
     self.azurePassword = azureDeploymnetCredentialPassword;
+    self.azureDeploymentDomain = (typeof azureDeploymentDomain === 'undefined') ? 'scm.azurewebsites.net' : azureDeploymentDomain;
 }
 
 AzureWebSiteDeploymentManager.prototype.deploy = function (sourceDir) {
     var self = this;
 
     // https://{{username}}:{{password}}@{{project}}.scm.azurewebsites.net:443/{{project}}.git
-    var repositoryUri = "https://" + self.azureUserName + ":" + self.azurePassword + "@" + self.azureWebSiteName + ".scm.azurewebsites.net:443/" + self.azureWebSiteName + ".git";
+    var repositoryUri = "https://" + self.azureUserName + ":" + self.azurePassword + "@" + self.azureWebSiteName + "." + self.azureDeploymentDomain + ":443/" + self.azureWebSiteName + ".git";
 
     var currentTempDir;
     var currentGitRepository;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-deploy",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "description": "A module the deploy azure websites",
   "main": "lib/azure-deploy.js",
   "author": "dei79",


### PR DESCRIPTION
Hi There,

We've just started using this package to do some deployment automation to our Azure App Service Environment web sites.  The app services/web sites are named slightly different when you use them inside of an App Service Environment when it comes to the Git endpoints.  For example:

Standard: https://<site>.scm.azurewebsites.net:443/<site>.git
ASE: https://<site>.scm.<app service env name>.p.azurewebsites.net:443/<site>.git

This pull request is simply to add the ability to pass in that domain portion as an option like the user/pass to override the default you had there.

Thanks!

- Brian
